### PR TITLE
Add Predis connection component

### DIFF
--- a/APredisConnection.php
+++ b/APredisConnection.php
@@ -8,15 +8,17 @@
  *
  * Here's a sample configuration of the component:
  *
+ * <pre>
  * 		'redis'=>array(
- * 			'class'=>'ext.APredisConnection',
+ * 			'class'=>'ext.YiiRedis.APredisConnection',
  * 			'predisLibPath'=>'application.vendors.predis-0-8-3.lib.Predis',
  * 			'connectionParameters'=>array(
  * 				'database'=>0,
- * 				'host'=>'extcache1.servers.9squared.com',
+ * 				'host'=>'localhost',
  * 				'port'=>6379,
  * 			),
  * 		),
+ * </pre>
  *
  *
  * @author Konstantinos Filios <konfilios@gmail.com>

--- a/APredisConnection.php
+++ b/APredisConnection.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Represents a predis connection.
+ *
+ * This component relies on {@link https://github.com/nrk/predis Predis} library which is
+ * particularly useful on a Windows setup where {@link https://github.com/nicolasff/phpredis phpredis}
+ * build/installation might be either difficult or impossible.
+ *
+ * Here's a sample configuration of the component:
+ *
+ * 		'redis'=>array(
+ * 			'class'=>'ext.APredisConnection',
+ * 			'predisLibPath'=>'application.vendors.predis-0-8-3.lib.Predis',
+ * 			'connectionParameters'=>array(
+ * 				'database'=>0,
+ * 				'host'=>'extcache1.servers.9squared.com',
+ * 				'port'=>6379,
+ * 			),
+ * 		),
+ *
+ *
+ * @author Konstantinos Filios <konfilios@gmail.com>
+ * @package packages.redis
+ */
+class APredisConnection extends CApplicationComponent
+{
+	/**
+	 * Path alias of the predis client library.
+	 *
+	 * @var string
+	 */
+	public $predisLibPath = "ext.predis.Predis";
+
+	/**
+	 * Connection parameters for one or multiple servers.
+	 *
+	 * Corresponds to the first parameter of the
+	 * {@link https://github.com/nrk/predis/blob/v0.8/lib/Predis/Client.php Predis\Client}
+	 * constructor.
+	 *
+	 * @var mixed
+	 */
+	public $connectionParameters = array(
+		'host' => '127.0.0.1',
+		'port' => 6379
+	);
+
+	/**
+	 * Client options.
+	 *
+	 * Corresponds to the second parameter of the
+	 * {@link https://github.com/nrk/predis/blob/v0.8/lib/Predis/Client.php Predis\Client}
+	 * constructor.
+	 *
+	 * @var mixed
+	 */
+	public $clientOptions = null;
+
+	/**
+	 * User-defined commands.
+	 *
+	 * This is a hash of the form [$commandName => $commandClass] as expected in defineCommand()
+	 * {@link https://github.com/nrk/predis/blob/v0.8/lib/Predis/Profile/ServerProfile.php}
+	 *
+	 *
+	 * @var string[]
+	 */
+	public $defineCommands = array();
+
+	/**
+	 * Predis client instance.
+	 *
+	 * @var Predis\Client
+	 */
+	private $_client = null;
+
+	/**
+	 * Application component initialization.
+	 */
+	public function init()
+	{
+		parent::init();
+
+		if (!class_exists('Predis\\Client', false)) {
+			// Fix autoloader
+			require_once(Yii::getPathOfAlias($this->predisLibPath).'/Autoloader.php');
+			Predis\Autoloader::register();
+		}
+	}
+
+	/**
+	 * The predis client instance.
+	 *
+	 * @return Predis\Client 
+	 */
+	public function getClient()
+	{
+		if ($this->_client === null) {
+			// Create instance
+			$this->_client = new Predis\Client($this->connectionParameters, $this->clientOptions);
+
+			// Define commands
+			$profile = $this->_client->getProfile();
+			/* @var $profile Predis\Profile\ServerProfile */
+
+			// Make sure defineCommands is an array
+			if (empty($this->defineCommands)) {
+				$this->defineCommands = array();
+			}
+
+			if (!isset($this->defineCommands['delete'])) {
+				$this->defineCommands['delete'] = 'Predis\Command\KeyDelete';
+			}
+
+			foreach ($this->defineCommands as $alias=>$command) {
+				$profile->defineCommand($alias, $command);
+			}
+		}
+
+		return $this->_client;
+	}
+
+	/**
+	 * Forward call to client instance.
+	 */
+	public function __call($method, $args)
+	{
+		return call_user_func_array(array($this->getClient(), $method), $args);
+	}
+
+}


### PR DESCRIPTION
Hi Charles,

   I happen to use predis (instead of phpredis) because of several restrictions and limitations on my project's production servers. I found your components pretty useful but the only chance I can take advantage of them is to get a PredisConnection component similar to your RedisConnection component.

   I'm committing a APredisConnection component I've written and used in my project successfully in conjunction with your ARedisCache. Feel free to modify it so it fits your coding standards.
