### PR TITLE
prevent race condition when handling expired locks

### DIFF
--- a/ARedisMutex.php
+++ b/ARedisMutex.php
@@ -64,6 +64,13 @@ class ARedisMutex extends ARedisEntity {
 			if ($value > microtime(true)) {
 				return false;
 			}
+            else {
+                //prevent a race codition if another process finds it expired at the same time
+                $current = $redis->getset($this->name, $this->getExpiresAt(true));
+                if ($value != $current){
+                    return false; 
+                }
+            }
 		}
 		$this->afterLock();
 		return true;

--- a/ARedisMutex.php
+++ b/ARedisMutex.php
@@ -64,13 +64,13 @@ class ARedisMutex extends ARedisEntity {
 			if ($value > microtime(true)) {
 				return false;
 			}
-            else {
-                //prevent a race codition if another process finds it expired at the same time
-                $current = $redis->getset($this->name, $this->getExpiresAt(true));
-                if ($value != $current){
-                    return false; 
-                }
-            }
+			else {
+				//prevent a race codition if another process finds it expired at the same time
+				$current = $redis->getset($this->name, $this->getExpiresAt(true));
+				if ($value != $current){
+					return false; 
+				}
+			}
 		}
 		$this->afterLock();
 		return true;


### PR DESCRIPTION
Fixes a race condition when multiple clients detect an expired lock and are trying to release it.

See "Handling deadlocks" here: http://redis.io/commands/setnx.
