### PR TITLE
hset return value fix

### DIFF
--- a/ARedisHash.php
+++ b/ARedisHash.php
@@ -21,7 +21,7 @@ class ARedisHash extends ARedisIterableEntity {
 		if ($this->name === null) {
 			throw new CException(get_class($this)." requires a name!");
 		}
-		if (!$this->getConnection()->getClient()->hset($this->name,$key, $value)) {
+		if ($this->getConnection()->getClient()->hset($this->name,$key, $value) === false) {
 			return false;
 		}
 		$this->_data = null;


### PR DESCRIPTION
Redis hset returns 0 if key exists, it is not a failure condition and should not be treated as one in ARedisHash::add
